### PR TITLE
Fix function check

### DIFF
--- a/libh2o_http_server/libh2o_http_server.c
+++ b/libh2o_http_server/libh2o_http_server.c
@@ -339,7 +339,7 @@ static void callback_on_http_resp_timeout(struct notification_http_conn_t *conn)
     struct server_context_t *c = conn->cmn.c;
     struct http_server_init_t *p = &c->server_init;
 
-    if (p->cb.on_http_req) {
+    if (p->cb.on_http_resp_timeout) {
         p->cb.on_http_resp_timeout(p->cb.param, &conn->req);
     }
 }


### PR DESCRIPTION
There was an error when resp time out is called, it was checking if `on_http_req` instead of `on_http_resp_timeout`